### PR TITLE
Don't mention `std::env::set_exit_status()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Preferred system exit codes as defined by sysexits.h
 //!
 //! Exit code constants intended to be passed to
-//! `std::env::set_exit_status!()` or `std::process::exit()`
+//! `std::process::exit()`
 //!
 //! # Example:
 //! ```


### PR DESCRIPTION
It was never stable, and was removed in Rust 1.4.0.