### PR TITLE
Update docs and tests examples.  Bump to `v1.0.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "exitcode"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Ben Wilber <benwilber@gmail.com>"]
 description = "Preferred system exit codes as defined by sysexits.h"
-documentation = "https://github.com/benwilber/exitcode"
+documentation = "https://docs.rs/exitcode"
 homepage = "https://github.com/benwilber/exitcode"
 repository = "https://github.com/benwilber/exitcode"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Documentation is available [here](https://docs.rs/exitcode)
 # Installing from [crates.io](https://crates.io/crates/exitcode)
 ```
 [dependencies]
-exitcode = "1.0.0"
+exitcode = "1.0.1"
 ```
 # Example
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Example:
 //! ```
-//! use exitcode;
+//! extern crate exitcode;
 //!
 //! ::std::process::exit(exitcode::OK);
 //! ```
@@ -89,7 +89,8 @@ pub const CONFIG: i32 = 78;
 ///
 /// # Example:
 /// ```
-/// use exitcode;
+/// extern crate exitcode;
+///
 /// assert!(exitcode::is_success(exitcode::OK));
 /// assert!(!exitcode::is_success(exitcode::USAGE));
 /// ```
@@ -101,7 +102,8 @@ pub fn is_success(code: i32) -> bool {
 ///
 /// # Example:
 /// ```
-/// use exitcode;
+/// extern crate exitcode;
+///
 /// assert!(exitcode::is_error(exitcode::USAGE));
 /// assert!(!exitcode::is_error(exitcode::OK));
 /// ```


### PR DESCRIPTION
* Update docs link
* Update tests examples to just use `extern create exitcode;`
* Bump release to `v1.0.1`