### PR TITLE
Define the ExitCode type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,80 +10,83 @@
 //! ::std::process::exit(exitcode::OK);
 //! ```
 
+/// Alias for the numeric type that holds system exit codes.
+pub type ExitCode = i32;
+
 /// Successful exit
-pub const OK: i32 = 0;
+pub const OK: ExitCode = 0;
 
 /// The command was used incorrectly, e.g., with the
 /// wrong number of arguments, a bad flag, a bad syntax
 /// in a parameter, etc.
-pub const USAGE: i32 = 64;
+pub const USAGE: ExitCode = 64;
 
 /// The input data was incorrect in some way.  This
 /// should only be used for user's data and not system
 /// files.
-pub const DATAERR: i32 = 65;
+pub const DATAERR: ExitCode = 65;
 
 /// An input file (not a system file) did not exist or
 /// was not readable.  This could also include errors
 /// like "No message" to a mailer (if it cared to
 /// catch it).
-pub const NOINPUT: i32 = 66;
+pub const NOINPUT: ExitCode = 66;
 
 /// The user specified did not exist.  This might be
 /// used for mail addresses or remote logins.
-pub const NOUSER: i32 = 67;
+pub const NOUSER: ExitCode = 67;
 
 /// The host specified did not exist.  This is used in
 /// mail addresses or network requests.
-pub const NOHOST: i32 = 68;
+pub const NOHOST: ExitCode = 68;
 
 /// A service is unavailable.  This can occur if a
 /// support program or file does not exist. This can also
 /// be used as a catchall message when something you
 /// wanted to do doesn't work, but you don't know why.
-pub const UNAVAILABLE: i32 = 69;
+pub const UNAVAILABLE: ExitCode = 69;
 
 /// An internal software error has been detected.  This
 /// should be limited to non-operating system related
 /// errors as possible.
-pub const SOFTWARE: i32 = 70;
+pub const SOFTWARE: ExitCode = 70;
 
 /// An operating system error has been detected.  This
 /// is intended to be used for such things as "cannot
 /// fork", "cannot create pipe", or the like.  It
 /// includes things like getuid returning a user that
 /// does not exist in the passwd file.
-pub const OSERR: i32 = 71;
+pub const OSERR: ExitCode = 71;
 
 /// Some system file (e.g., /etc/passwd, /var/run/utmp,
 /// etc.) does not exist, cannot be opened, or has some
 /// sort of error (e.g., syntax error).
-pub const OSFILE: i32 = 72;
+pub const OSFILE: ExitCode = 72;
 
 /// A (user specified) output file cannot be created.
-pub const CANTCREAT: i32 = 73;
+pub const CANTCREAT: ExitCode = 73;
 
 /// An error occurred while doing I/O on some file.
-pub const IOERR: i32 = 74;
+pub const IOERR: ExitCode = 74;
 
 /// Temporary failure, indicating something that is not
 /// really an error.  In sendmail, this means that a
 /// mailer (e.g.) could not create a connection, and
 /// the request should be reattempted later.
-pub const TEMPFAIL: i32 = 75;
+pub const TEMPFAIL: ExitCode = 75;
 
 /// The remote system returned something that was
 /// "not possible" during a protocol exchange.
-pub const PROTOCOL: i32 = 76;
+pub const PROTOCOL: ExitCode = 76;
 
 /// You did not have sufficient permission to perform
 /// the operation.  This is not intended for file system
 /// problems, which should use `NOINPUT` or `CANTCREAT`,
 /// but rather for higher level permissions.
-pub const NOPERM: i32 = 77;
+pub const NOPERM: ExitCode = 77;
 
 /// Something was found in an unconfigured or misconfigured state.
-pub const CONFIG: i32 = 78;
+pub const CONFIG: ExitCode = 78;
 
 /// Check if exit code given by `code` is successful
 ///
@@ -94,7 +97,7 @@ pub const CONFIG: i32 = 78;
 /// assert!(exitcode::is_success(exitcode::OK));
 /// assert!(!exitcode::is_success(exitcode::USAGE));
 /// ```
-pub fn is_success(code: i32) -> bool {
+pub fn is_success(code: ExitCode) -> bool {
     code == OK
 }
 
@@ -107,6 +110,6 @@ pub fn is_success(code: i32) -> bool {
 /// assert!(exitcode::is_error(exitcode::USAGE));
 /// assert!(!exitcode::is_error(exitcode::OK));
 /// ```
-pub fn is_error(code: i32) -> bool {
+pub fn is_error(code: ExitCode) -> bool {
     !is_success(code)
 }


### PR DESCRIPTION
I'd like to define a type alias for holding the exit code. One benefit of having it is better signatures of functions that either return or accept exist codes.

Here's a slightly contrived example:
```rust
use std::process;
use exitcode::{self, ExitCode};

fn main() {
    let config = load_config();
    process::exit(do_stuff(&config).err().unwrap_or(exitcode::OK));
}

fn do_stuff(config: &Config) -> Result<(), ExitCode> {
}
```

And here's [a real one](https://github.com/Xion/gisht/blob/2a4cebcdc4132fabd1d0de2224f2de59f0293960/src/main.rs#L153) (though not using the crate yet).